### PR TITLE
feat: added dynamodb to serverless lambdas

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,7 +66,7 @@
 				"no-ex-assign": "error",
 				"no-import-assign": "error",
 				"no-promise-executor-return": "error",
-				"no-template-curly-in-string": "error",
+				"no-template-curly-in-string": "warn",
 				"no-unmodified-loop-condition": "error",
 				"no-unreachable-loop": "error",
 				"eqeqeq": "error",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ Follow the steps:
 
 - [CloudFront Host](https://d1w03e00wp0frf.cloudfront.net/) should work properly
 
-- [Get Products List](https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev/products) should return product list
+- [Get Products List](https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev/products) should return product list
 
-- [Get Product by Id](https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev/products/7567ec4b-b10c-48c5-9345-fc73c48a80a0) should return product by id
+- [Get Product by Id](https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev/products/7567ec4b-b10c-48c5-9345-fc73c48a80a0) should return product by id

--- a/cspell.json
+++ b/cspell.json
@@ -16,7 +16,16 @@
 	],
 	"dictionaryDefinitions": [],
 	"language": "en,es",
-	"dictionaries": ["Spanish", "corp-terms", "fonts", "filetypes", "companies", "node", "typescript", "npm"],
+	"dictionaries": [
+		"Spanish",
+		"corp-terms",
+		"fonts",
+		"filetypes",
+		"companies",
+		"node",
+		"typescript",
+		"npm"
+	],
 	"words": [
 		"angular",
 		"camelCase",
@@ -29,13 +38,14 @@
 		"husky",
 		"jasmine",
 		"kebab-case",
+		"middyfy",
 		"node_modules",
+		"openapi",
 		"rxjs",
+		"unmarshall",
 		"webRoot",
 		"workspaceFolder",
-		"yarn",
-		"middyfy",
-		"openapi"
+		"yarn"
 	],
 	"languageSettings": [
 		{
@@ -48,5 +58,7 @@
 		}
 	],
 	"ignoreWords": [],
-	"import": ["@cspell/dict-es-es/cspell-ext.json"]
+	"import": [
+		"@cspell/dict-es-es/cspell-ext.json"
+	]
 }

--- a/shop-angular-cloudfront/package.json
+++ b/shop-angular-cloudfront/package.json
@@ -8,7 +8,9 @@
 		"test": "ng test",
 		"e2e": "ng e2e",
 		"client:deploy": "yarn build && npx --no-install sls client deploy --no-confirm",
-		"sls:deploy": "sls deploy"
+		"sls:deploy": "sls deploy",
+		"aws:sync:client": "yarn build && aws s3 sync ./dist/app/ s3://aws-learn-cloud-practitioner-angular-shop-front-end/",
+		"aws:rm:client": "aws s3 rm s3://aws-learn-cloud-practitioner-angular-shop-front-end/ --recursive"
 	},
 	"private": true,
 	"dependencies": {

--- a/shop-angular-cloudfront/src/environments/environment.prod.ts
+++ b/shop-angular-cloudfront/src/environments/environment.prod.ts
@@ -3,11 +3,11 @@ import { Config } from './config.interface'
 export const environment: Config = {
 	production: true,
 	apiEndpoints: {
-		product: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev',
-		order: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev',
-		import: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev',
-		bff: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev',
-		cart: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev'
+		product: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev',
+		order: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev',
+		import: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev',
+		bff: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev',
+		cart: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev'
 	},
 	apiEndpointsEnabled: {
 		product: false,

--- a/shop-angular-cloudfront/src/environments/environment.ts
+++ b/shop-angular-cloudfront/src/environments/environment.ts
@@ -7,11 +7,11 @@ import { Config } from './config.interface'
 export const environment: Config = {
 	production: false,
 	apiEndpoints: {
-		product: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev',
-		order: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev',
-		import: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev',
-		bff: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev',
-		cart: 'https://vc20i23gc5.execute-api.us-east-1.amazonaws.com/dev'
+		product: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev',
+		order: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev',
+		import: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev',
+		bff: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev',
+		cart: 'https://wy90rfbtf9.execute-api.us-east-1.amazonaws.com/dev'
 	},
 	apiEndpointsEnabled: {
 		product: false,

--- a/shop-api-lambdas/db/seed.sh
+++ b/shop-api-lambdas/db/seed.sh
@@ -1,0 +1,16 @@
+aws dynamodb put-item \
+    --table-name products \
+    --item '{
+        "id": {"S": "7567ec4b-b10c-48c5-9345-fc73c48a80aa"},
+        "title": {"S": "ProductOne"}, 
+        "description": {"S": "Short Product Description1"}, 
+        "price": {"N": "200"}
+        }'
+
+aws dynamodb put-item \
+    --table-name stocks \
+    --item '{
+        "id": {"S": "7567ec4b-b10c-48c5-9345-fc73c48a80aa"},
+        "product_id": {"S": "7567ec4b-b10c-48c5-9345-fc73c48a80aa"},
+        "count": {"N": "4"}
+        }'

--- a/shop-api-lambdas/package.json
+++ b/shop-api-lambdas/package.json
@@ -12,6 +12,8 @@
 		"node": ">=14.15.0"
 	},
 	"dependencies": {
+		"@aws-sdk/client-dynamodb": "^3.540.0",
+		"@aws-sdk/util-dynamodb": "^3.540.0",
 		"@middy/core": "^3.4.0",
 		"@middy/http-json-body-parser": "^3.4.0"
 	},

--- a/shop-api-lambdas/serverless.ts
+++ b/shop-api-lambdas/serverless.ts
@@ -5,7 +5,7 @@ import type { AWS } from '@serverless/typescript'
 const serverlessConfiguration: AWS = {
 	service: 'get-products',
 	frameworkVersion: '3',
-	plugins: ['serverless-esbuild'],
+	plugins: [ 'serverless-esbuild' ],
 	provider: {
 		name: 'aws',
 		runtime: 'nodejs20.x',
@@ -16,6 +16,22 @@ const serverlessConfiguration: AWS = {
 		environment: {
 			AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
 			NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000'
+		},
+		iam: {
+			role: {
+				statements: [
+					{
+						Effect: 'Allow',
+						Action: [ 'dynamodb:Scan', 'dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem' ],
+						Resource: 'arn:aws:dynamodb:us-east-1:*:table/products'
+					},
+					{
+						Effect: 'Allow',
+						Action: [ 'dynamodb:Scan', 'dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem' ],
+						Resource: 'arn:aws:dynamodb:us-east-1:*:table/stocks'
+					}
+				]
+			}
 		}
 	},
 	// import the function via paths
@@ -29,7 +45,7 @@ const serverlessConfiguration: AWS = {
 			bundle: true,
 			minify: false,
 			sourcemap: true,
-			exclude: ['aws-sdk'],
+			exclude: [ 'aws-sdk' ],
 			target: 'node14',
 			define: { 'require.resolve': undefined },
 			platform: 'node',

--- a/shop-api-lambdas/serverless.ts
+++ b/shop-api-lambdas/serverless.ts
@@ -1,3 +1,4 @@
+import createProduct from '@functions/create-product'
 import getProductsById from '@functions/get-product-by-id'
 import getProductsList from '@functions/get-products-list'
 import type { AWS } from '@serverless/typescript'
@@ -14,6 +15,9 @@ const serverlessConfiguration: AWS = {
 			shouldStartNameWithService: true
 		},
 		environment: {
+			MAIN_AWS_REGION: 'us-east-1',
+			PRODUCTS_TABLE: 'products',
+			STOCKS_TABLE: 'stocks',
 			AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
 			NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000'
 		},
@@ -23,12 +27,12 @@ const serverlessConfiguration: AWS = {
 					{
 						Effect: 'Allow',
 						Action: [ 'dynamodb:Scan', 'dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem' ],
-						Resource: 'arn:aws:dynamodb:us-east-1:*:table/products'
+						Resource: 'arn:aws:dynamodb:${self:provider.environment.MAIN_AWS_REGION}:*:table/${self:provider.environment.PRODUCTS_TABLE}'
 					},
 					{
 						Effect: 'Allow',
 						Action: [ 'dynamodb:Scan', 'dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem' ],
-						Resource: 'arn:aws:dynamodb:us-east-1:*:table/stocks'
+						Resource: 'arn:aws:dynamodb:${self:provider.environment.MAIN_AWS_REGION}:*:table/${self:provider.environment.STOCKS_TABLE}'
 					}
 				]
 			}
@@ -37,7 +41,8 @@ const serverlessConfiguration: AWS = {
 	// import the function via paths
 	functions: {
 		getProductsList,
-		getProductsById
+		getProductsById,
+		createProduct
 	},
 	package: { individually: true },
 	custom: {

--- a/shop-api-lambdas/serverless.ts
+++ b/shop-api-lambdas/serverless.ts
@@ -10,6 +10,7 @@ const serverlessConfiguration: AWS = {
 	provider: {
 		name: 'aws',
 		runtime: 'nodejs20.x',
+		httpApi: { cors: true },
 		apiGateway: {
 			minimumCompressionSize: 1024,
 			shouldStartNameWithService: true

--- a/shop-api-lambdas/src/config/config.ts
+++ b/shop-api-lambdas/src/config/config.ts
@@ -1,0 +1,6 @@
+export const DYNAMO_DB_TABLES = {
+    products: process.env.PRODUCTS_TABLE,
+    stocks: process.env.STOCKS_TABLE
+}
+
+export const AWS_CONFIGS = { region: process.env.MAIN_AWS_REGION }

--- a/shop-api-lambdas/src/functions/create-product/handler.ts
+++ b/shop-api-lambdas/src/functions/create-product/handler.ts
@@ -1,0 +1,16 @@
+import type { APIGatewayEvent, Handler } from 'aws-lambda'
+import { ProductStock } from 'src/types/ProductStock'
+
+import { formatJSONResponse } from '../../libs/api-gateway'
+import { ProductService } from '../../service/products.service'
+
+const createProduct: Handler = async (event: APIGatewayEvent) => {
+
+	const newProductStock: ProductStock = JSON.parse(event.body)
+
+	const productStock = await new ProductService().createProduct(newProductStock)
+
+	return formatJSONResponse(productStock)
+}
+
+export const main = createProduct

--- a/shop-api-lambdas/src/functions/create-product/handler.ts
+++ b/shop-api-lambdas/src/functions/create-product/handler.ts
@@ -6,6 +6,8 @@ import { ProductService } from '../../service/products.service'
 
 const createProduct: Handler = async (event: APIGatewayEvent) => {
 
+	console.log('createProduct event.body', event.body)
+
 	const newProductStock: ProductStock = JSON.parse(event.body)
 
 	const productStock = await new ProductService().createProduct(newProductStock)

--- a/shop-api-lambdas/src/functions/create-product/index.ts
+++ b/shop-api-lambdas/src/functions/create-product/index.ts
@@ -1,0 +1,13 @@
+import { handlerPath } from '@libs/handler-resolver'
+
+export default {
+	handler: `${handlerPath(__dirname)}/handler.main`,
+	events: [
+		{
+			http: {
+				method: 'post',
+				path: 'products'
+			}
+		}
+	]
+}

--- a/shop-api-lambdas/src/functions/create-product/mock.json
+++ b/shop-api-lambdas/src/functions/create-product/mock.json
@@ -1,0 +1,6 @@
+{
+	"headers": {
+		"Content-Type": "application/json"
+	},
+	"body": "{\"count\": 10,\"description\": \"High-quality T-shirt made from organic cotton\",\"price\": 19.99,\"title\": \"Organic Cotton T-shirt\"}"
+}

--- a/shop-api-lambdas/src/functions/get-product-by-id/handler.ts
+++ b/shop-api-lambdas/src/functions/get-product-by-id/handler.ts
@@ -6,11 +6,9 @@ import { ProductService } from '../../service/products.service'
 const getProduct: Handler = async (event: APIGatewayEvent) => {
 	const { id } = event.pathParameters
 
-	const productService = new ProductService()
+	const productStock = await new ProductService().getProductById(id)
 
-	const product = productService.getProductById(id)
-
-	return formatJSONResponse(product, product ? 200 : 404)
+	return formatJSONResponse(productStock, productStock ? 200 : 404)
 }
 
 export const main = getProduct

--- a/shop-api-lambdas/src/functions/get-product-by-id/handler.ts
+++ b/shop-api-lambdas/src/functions/get-product-by-id/handler.ts
@@ -4,6 +4,9 @@ import { formatJSONResponse } from '../../libs/api-gateway'
 import { ProductService } from '../../service/products.service'
 
 const getProduct: Handler = async (event: APIGatewayEvent) => {
+
+	console.log('getProduct event.pathParameters', event.pathParameters)
+
 	const { id } = event.pathParameters
 
 	const productStock = await new ProductService().getProductById(id)

--- a/shop-api-lambdas/src/functions/get-product-by-id/mock.json
+++ b/shop-api-lambdas/src/functions/get-product-by-id/mock.json
@@ -3,6 +3,6 @@
 		"Content-Type": "application/json"
 	},
 	"pathParameters": {
-		"id": "7567ec4b-b10c-48c5-9345-fc73c48a80a0"
+		"id": "7567ec4b-b10c-48c5-9345-fc73c48a80aa"
 	}
 }

--- a/shop-api-lambdas/src/functions/get-products-list/handler.ts
+++ b/shop-api-lambdas/src/functions/get-products-list/handler.ts
@@ -5,9 +5,9 @@ import { ProductService } from '../../service/products.service'
 
 const getProducts: Handler = async () => {
 
-	const productService = new ProductService()
+	const productStockList = await new ProductService().getProducts()
 
-	return formatJSONResponse(productService.getProducts())
+	return formatJSONResponse(productStockList)
 }
 
 export const main = getProducts

--- a/shop-api-lambdas/src/functions/get-products-list/handler.ts
+++ b/shop-api-lambdas/src/functions/get-products-list/handler.ts
@@ -5,6 +5,8 @@ import { ProductService } from '../../service/products.service'
 
 const getProducts: Handler = async () => {
 
+	console.log('getProducts with no events')
+
 	const productStockList = await new ProductService().getProducts()
 
 	return formatJSONResponse(productStockList)

--- a/shop-api-lambdas/src/libs/util.ts
+++ b/shop-api-lambdas/src/libs/util.ts
@@ -1,0 +1,8 @@
+export function uuid() {
+    const timestamp = Math.floor(Date.now() / 100).toString(16)
+    const randomId = Math.floor(Math.random() * 16777216).toString(16)
+    const processId = process.pid.toString(16)
+    const counter = Math.floor(Date.now() * 100).toString(16)
+
+    return `${timestamp}-${randomId}-${processId}-${counter}`
+}

--- a/shop-api-lambdas/src/service/products.service.ts
+++ b/shop-api-lambdas/src/service/products.service.ts
@@ -1,15 +1,17 @@
-import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb'
-import { unmarshall } from '@aws-sdk/util-dynamodb'
+import { DynamoDBClient, PutItemCommand, ScanCommand } from '@aws-sdk/client-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+import { uuid } from '@libs/util'
+import { AWS_CONFIGS, DYNAMO_DB_TABLES } from 'src/config/config'
 
 import { Product, ProductStock, Stock } from '../types/ProductStock'
 
 export class ProductService {
 
-	private readonly documentClient = new DynamoDBClient({ region: 'us-east-1' })
+	private readonly documentClient = new DynamoDBClient({ region: AWS_CONFIGS.region })
 
 	async getProducts(): Promise<ProductStock[]> {
 
-		const scanCommand = new ScanCommand({ TableName: 'products' })
+		const scanCommand = new ScanCommand({ TableName: DYNAMO_DB_TABLES.products })
 
 		const scanCommandOutput = await this.documentClient.send(scanCommand)
 
@@ -25,7 +27,7 @@ export class ProductService {
 			} as ProductStock
 		})
 
-		const productStockList: ProductStock[] = await Promise.all(promises)
+		const productStockList = await Promise.all(promises)
 
 		return productStockList
 	}
@@ -33,8 +35,7 @@ export class ProductService {
 	async getProductById(id: string): Promise<ProductStock> {
 
 		const scanCommand = new ScanCommand({
-			TableName: 'products',
-			Limit: 1,
+			TableName: DYNAMO_DB_TABLES.products,
 			FilterExpression: 'id = :id',
 			ExpressionAttributeValues: { ':id': { 'S': id } }
 		})
@@ -53,15 +54,50 @@ export class ProductService {
 		return productStock
 	}
 
+	async createProduct(newProductStock: ProductStock): Promise<ProductStock> {
+
+		const { count, ...newProduct } = newProductStock
+
+		const product = {
+			...newProduct,
+			id: uuid()
+		}
+
+		const stock = {
+			product_id: product.id,
+			count,
+			id: uuid()
+		}
+
+		const putProductCommand = new PutItemCommand({
+			TableName: DYNAMO_DB_TABLES.products, Item: marshall(product)
+		})
+
+		const putStockCommand = new PutItemCommand({
+			TableName: DYNAMO_DB_TABLES.stocks, Item: marshall(stock)
+		})
+
+		await Promise.all([
+			await this.documentClient.send(putProductCommand),
+			await this.documentClient.send(putStockCommand)
+		])
+
+		return {
+			...product,
+			count: stock.count
+		}
+	}
+
 	private async getStockByProductId(productId: string): Promise<Stock> {
 		const scanCommand = new ScanCommand({
-			TableName: 'stocks',
-			Limit: 1,
+			TableName: DYNAMO_DB_TABLES.stocks,
 			FilterExpression: 'product_id = :productId',
 			ExpressionAttributeValues: { ':productId': { 'S': productId } }
 		})
 
 		const scanCommandOutput = await this.documentClient.send(scanCommand)
+
+		console.log(scanCommandOutput.Items)
 
 		const stock = unmarshall(scanCommandOutput.Items[ 0 ]) as Stock
 

--- a/shop-api-lambdas/src/types/ProductStock.ts
+++ b/shop-api-lambdas/src/types/ProductStock.ts
@@ -1,5 +1,5 @@
 export type Product = {
-    id: string
+    id?: string
     title: string
     description: string
     price: number

--- a/shop-api-lambdas/src/types/ProductStock.ts
+++ b/shop-api-lambdas/src/types/ProductStock.ts
@@ -1,0 +1,14 @@
+export type Product = {
+    id: string
+    title: string
+    description: string
+    price: number
+}
+
+export type Stock = {
+    id: string
+    product_id: string
+    count: number
+}
+
+export type ProductStock = Product & Omit<Stock, 'product_id' | 'id'>

--- a/shop-api-lambdas/yarn.lock
+++ b/shop-api-lambdas/yarn.lock
@@ -121,6 +121,55 @@
     tslib "^2.6.2"
     uuid "^9.0.1"
 
+"@aws-sdk/client-dynamodb@^3.540.0":
+  version "3.540.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-3.540.0.tgz#cb2edbfb8fa03b9f38c576ca0d32ddf6f8b79e46"
+  integrity sha512-AL4ZNb3q8WFZWlwybHNmipcBp1981pjzav6gIemWdmkrveVkNVEFmYHBEo9ONLKDDwoDsgxKUhATCLGrioWQJQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/client-sts" "3.540.0"
+    "@aws-sdk/core" "3.535.0"
+    "@aws-sdk/credential-provider-node" "3.540.0"
+    "@aws-sdk/middleware-endpoint-discovery" "3.535.0"
+    "@aws-sdk/middleware-host-header" "3.535.0"
+    "@aws-sdk/middleware-logger" "3.535.0"
+    "@aws-sdk/middleware-recursion-detection" "3.535.0"
+    "@aws-sdk/middleware-user-agent" "3.540.0"
+    "@aws-sdk/region-config-resolver" "3.535.0"
+    "@aws-sdk/types" "3.535.0"
+    "@aws-sdk/util-endpoints" "3.540.0"
+    "@aws-sdk/util-user-agent-browser" "3.535.0"
+    "@aws-sdk/util-user-agent-node" "3.535.0"
+    "@smithy/config-resolver" "^2.2.0"
+    "@smithy/core" "^1.4.0"
+    "@smithy/fetch-http-handler" "^2.5.0"
+    "@smithy/hash-node" "^2.2.0"
+    "@smithy/invalid-dependency" "^2.2.0"
+    "@smithy/middleware-content-length" "^2.2.0"
+    "@smithy/middleware-endpoint" "^2.5.0"
+    "@smithy/middleware-retry" "^2.2.0"
+    "@smithy/middleware-serde" "^2.3.0"
+    "@smithy/middleware-stack" "^2.2.0"
+    "@smithy/node-config-provider" "^2.3.0"
+    "@smithy/node-http-handler" "^2.5.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/smithy-client" "^2.5.0"
+    "@smithy/types" "^2.12.0"
+    "@smithy/url-parser" "^2.2.0"
+    "@smithy/util-base64" "^2.3.0"
+    "@smithy/util-body-length-browser" "^2.2.0"
+    "@smithy/util-body-length-node" "^2.3.0"
+    "@smithy/util-defaults-mode-browser" "^2.2.0"
+    "@smithy/util-defaults-mode-node" "^2.3.0"
+    "@smithy/util-endpoints" "^1.2.0"
+    "@smithy/util-middleware" "^2.2.0"
+    "@smithy/util-retry" "^2.2.0"
+    "@smithy/util-utf8" "^2.3.0"
+    "@smithy/util-waiter" "^2.2.0"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
 "@aws-sdk/client-sso-oidc@3.540.0":
   version "3.540.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.540.0.tgz#e4c52889d33ca969add269011b790f2d634fb6d2"
@@ -362,6 +411,26 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/endpoint-cache@3.535.0":
+  version "3.535.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/endpoint-cache/-/endpoint-cache-3.535.0.tgz#cd230b03065e2b32675a8b3f1514c8bfb13d50ba"
+  integrity sha512-sPG2l00iVuporK9AmPWq4UBcJURs2RN+vKA8QLRQANmQS3WFHWHamvGltxCjK79izkeqri882V4XlFpZfWhemA==
+  dependencies:
+    mnemonist "0.38.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-endpoint-discovery@3.535.0":
+  version "3.535.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.535.0.tgz#204b2e7f50059bc8ed187d15ae23a53483920d00"
+  integrity sha512-+EsqJB5A15RoTf0HxUdknF3hp+2WDg0HWc+QERUctzzYXy9l5LIQjmhQ96cWDyFttKmHE+4h6fjMZjJEeWOeYQ==
+  dependencies:
+    "@aws-sdk/endpoint-cache" "3.535.0"
+    "@aws-sdk/types" "3.535.0"
+    "@smithy/node-config-provider" "^2.3.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-host-header@3.535.0":
   version "3.535.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.535.0.tgz#d5264f813592f5e77df25e5a14bbb0e6441812db"
@@ -432,6 +501,13 @@
   integrity sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==
   dependencies:
     "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-dynamodb@^3.540.0":
+  version "3.540.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-dynamodb/-/util-dynamodb-3.540.0.tgz#ba1a675c477ea7b7cecd9a7d6f87132774ae0fb7"
+  integrity sha512-Er3OCddj5MhJIpX4jzjeHpvyTcYk+LE1b2Efaku1xT8LeQ29mhg+6BFPsbYydqIas5KLQd8AiNVWBWN8qdpLRA==
+  dependencies:
     tslib "^2.6.2"
 
 "@aws-sdk/util-endpoints@3.540.0":
@@ -1222,12 +1298,12 @@
     tslib "^2.6.2"
 
 "@smithy/core@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-1.4.0.tgz#5f9f86b681b9cbf23904041dad6f0531efe8375e"
-  integrity sha512-uu9ZDI95Uij4qk+L6kyFjdk11zqBkcJ3Lv0sc6jZrqHvLyr0+oeekD3CnqMafBn/5PRI6uv6ulW3kNLRBUHeVw==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-1.4.1.tgz#42d1413ccade7c9a5418d739df68f5f6a039a7c0"
+  integrity sha512-jCnbEQHvTOUQXxXOS110FIMc83dCXUlrqiG/q0QzUSYhglDj9bJVPFjXmxc6qUfARe0mEb8h9LeVoh7FUYHuUg==
   dependencies:
     "@smithy/middleware-endpoint" "^2.5.0"
-    "@smithy/middleware-retry" "^2.2.0"
+    "@smithy/middleware-retry" "^2.3.0"
     "@smithy/middleware-serde" "^2.3.0"
     "@smithy/protocol-http" "^3.3.0"
     "@smithy/smithy-client" "^2.5.0"
@@ -1314,10 +1390,10 @@
     "@smithy/util-middleware" "^2.2.0"
     tslib "^2.6.2"
 
-"@smithy/middleware-retry@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-2.2.0.tgz#ff48ac01ad57394eeea15a0146a86079cf6364b7"
-  integrity sha512-PsjDOLpbevgn37yJbawmfVoanru40qVA8UEf2+YA1lvOefmhuhL6ZbKtGsLAWDRnE1OlAmedsbA/htH6iSZjNA==
+"@smithy/middleware-retry@^2.2.0", "@smithy/middleware-retry@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-2.3.0.tgz#b7b9a279f364b43e097cf96ca7a4192f361f3776"
+  integrity sha512-5H7kD0My2RkZryvYIWA4C9w6t/pdJfbgEdq+fcZhbnZsqHm/4vYFVjDsOzb5pC7PEpksuijoM9fGbM6eN4rLSg==
   dependencies:
     "@smithy/node-config-provider" "^2.3.0"
     "@smithy/protocol-http" "^3.3.0"
@@ -1327,7 +1403,7 @@
     "@smithy/util-middleware" "^2.2.0"
     "@smithy/util-retry" "^2.2.0"
     tslib "^2.6.2"
-    uuid "^8.3.2"
+    uuid "^9.0.1"
 
 "@smithy/middleware-serde@^2.3.0":
   version "2.3.0"
@@ -1602,9 +1678,9 @@
   integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
 
 "@tsconfig/node10@^1.0.7":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.10.tgz#b7ebd3adfa7750628d100594f6726b054d2c33b2"
-  integrity sha512-PiaIWIoPvO6qm6t114ropMCagj6YAF24j9OkCA2mJDXFnlionEwhsBCJ8yek4aib575BI3OkART/90WsgHgLWw==
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
 
 "@tsconfig/node12@^1.0.7":
   version "1.0.11"
@@ -1731,9 +1807,9 @@
   integrity sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==
 
 "@types/node@*":
-  version "20.11.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.30.tgz#9c33467fc23167a347e73834f788f4b9f399d66f"
-  integrity sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==
+  version "20.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.2.tgz#9facdd11102f38b21b4ebedd9d7999663343d72e"
+  integrity sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==
   dependencies:
     undici-types "~5.26.4"
 
@@ -1961,9 +2037,9 @@ available-typed-arrays@^1.0.7:
     possible-typed-array-names "^1.0.0"
 
 aws-sdk@^2.1404.0:
-  version "2.1584.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1584.0.tgz#3ffe7e9f2ae42587d80721cf17b4a93d2dda692c"
-  integrity sha512-57Qizb+bLOhrBLWQSWw6WXTtbO/lFKzLouHxTfm/QeXm38gs0Q0knFxhdH+sWc/DPPJYSRGy7MNiuQcmsq5zxA==
+  version "2.1589.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1589.0.tgz#b000aff456e2046c45c0d6a5d1e1281c14a7a7fe"
+  integrity sha512-Tt3UHH6hoUEAjbCscqvfEAoq9VSTN5iSQO9XSisiiH/QJo8sf+iLCYmfJHM4tVkd92bQH61/xxj9t2Mazwc/WQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -2249,9 +2325,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001587:
-  version "1.0.30001600"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz#93a3ee17a35aa6a9f0c6ef1b2ab49507d1ab9079"
-  integrity sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==
+  version "1.0.30001603"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001603.tgz#605046a5bdc95ba4a92496d67e062522dce43381"
+  integrity sha512-iL2iSS0eDILMb9n5yKQoTBim9jMZ0Yrk8g0N9K7UzYyWnfIKzXBZD5ngpM37ZcL/cv0Mli8XtVMRYMQAfFpi5Q==
 
 chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -2743,9 +2819,9 @@ duration@^0.2.2:
     es5-ext "~0.10.46"
 
 electron-to-chromium@^1.4.668:
-  version "1.4.715"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz#bb16bcf2a3537962fccfa746b5c98c5f7404ff46"
-  integrity sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==
+  version "1.4.722"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.722.tgz#99ae3484c5fc0f387d39ad98d77e1f259b9f4074"
+  integrity sha512-5nLE0TWFFpZ80Crhtp4pIp8LXCztjYX41yUcV6b+bKR2PqzjskTMOOlBi1VjBHlvHwS+4gar7kNKOrsbsewEZQ==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -3258,9 +3334,9 @@ formidable@^2.0.1:
     qs "^6.11.0"
 
 fp-ts@^2.13.1:
-  version "2.16.4"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.16.4.tgz#aab69636ee4a4e9849db762e549f65c4cb90f886"
-  integrity sha512-EkV/l6oHaf/w/DlVc5UiqLibqTV1S+idiDdcWQ+UjnLLflL9pZG28ebJfPLor8ifoL8NgEFDIo9fOvHyiSCrJQ==
+  version "2.16.5"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.16.5.tgz#d79b97168aeafcf9612f18bbc017f513ecb20ac9"
+  integrity sha512-N8T8PwMSeTKKtkm9lkj/zSTAnPC/aJIIrQhnHxxkL0KLsRCNUPANksJOlMXxcKKCo7H1ORP3No9EMD+fP0tsdA==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -4559,6 +4635,13 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mnemonist@0.38.3:
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.3.tgz#35ec79c1c1f4357cfda2fe264659c2775ccd7d9d"
+  integrity sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==
+  dependencies:
+    obliterator "^1.6.1"
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -4676,6 +4759,11 @@ object-inspect@^1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
   integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
+
+obliterator@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -5321,9 +5409,9 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 simple-git@^3.16.0:
-  version "3.23.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.23.0.tgz#e91d2e8c1dec234c48c57c424aa32b8f44e5e9d4"
-  integrity sha512-P9ggTW8vb/21CAL/AmnACAhqBDfnqSSZVpV7WuFtsFR9HLunf5IqQvk+OXAQTfkcZep8pKnt3DV3o7w3TegEkQ==
+  version "3.24.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.24.0.tgz#33a8c88dc6fa74e53eaf3d6bfc27d0182a49ec00"
+  integrity sha512-QqAKee9Twv+3k8IFOFfPB2hnk6as6Y6ACUpwCtQvRYBAes23Wv3SZlHVobAzqcE8gfsisCvPw3HGW3HYM+VYYw==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,5 @@
+//! S3 AND CLOUD FRONT
+
 provider "aws" {
   region = "us-east-1"
 }
@@ -102,4 +104,49 @@ data "aws_iam_policy_document" "front_end_bucket" {
 resource "aws_s3_bucket_policy" "front_end_bucket_policy" {
   bucket = aws_s3_bucket.front_end_bucket.id
   policy = data.aws_iam_policy_document.front_end_bucket.json
+}
+
+//! DYNAMO DB TABLES
+
+resource "aws_dynamodb_table" "dynamodb_table_products" {
+  name         = "products"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+  range_key    = "title"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "title"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "prducts-table"
+    Environment = "dev"
+  }
+}
+
+resource "aws_dynamodb_table" "dynamodb_table_stocks" {
+  name         = "stocks"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+  range_key    = "product_id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "product_id"
+    type = "S"
+  }
+  tags = {
+    Name        = "stocks-table"
+    Environment = "dev"
+  }
 }


### PR DESCRIPTION
done:

- added aws sdk for lambdas to use dynamodb
- added new policy to allow lambdas to read and write dynamodb tables
- added tf spec for dynamodb
- updated envs, readme, and dependencies
- added new environment for serverless tables and config
- added new service to create products
- added new handler for create products
- added new mock to test locally create products
- added util method to generate uuid
- allow cors on post request
- used transactions on create product and stock
- added logs on each lambda invocation

module: task-4